### PR TITLE
feat: expand dev infrastructure with observability, security, and goma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ REDIS_PORT=6379
 # --- SECURITY & TUNNELING ---
 # Required only if the 'proxy' profile is active.
 CLOUDFLARE_TOKEN=your_token_here
+
+GOMA_DB_URL=postgresql://user:password@postgres:5432/database?sslmode=disable
+GOMA_ADMIN_EMAIL=admin@example.com
+GOMA_ADMIN_PASSWORD=Admin@1234
+GOMA_JWT_SECRET=change-me-on-production

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,27 @@
+# --- STORAGE PATHS ---
+# Define where database data and tool configurations will be stored on your host machine.
+# WARNING: Deleting the local folders created at this path will result in PERMANENT DATA LOSS.
+# Default is current directory (.)
+DATA_PATH=.
+
+# --- NETWORKING ---
+# Define the bridge network name for cross-container communication.
+DOCKER_NETWORK=devtools
+
+# --- DATABASE CONFIGURATION ---
+# Shared credentials for MySQL, PostgreSQL, and Minio.
 DB_HOST=mysql
 DB_PORT=3306
 DB_DATABASE=test
 DB_USERNAME=default
 DB_PASSWORD=secret
+DB_EMAIL=admin@admin.com
 
+# --- CACHE & NO-SQL ---
 REDIS_HOST=redis
 REDIS_PASSWORD=secret
 REDIS_PORT=6379
+
+# --- SECURITY & TUNNELING ---
+# Required only if the 'proxy' profile is active.
+CLOUDFLARE_TOKEN=your_token_here

--- a/Makefile
+++ b/Makefile
@@ -1,86 +1,87 @@
 COMPOSE = docker compose
 ALL_PROFILES = COMPOSE_PROFILES="*"
+D ?= -d
+P ?= 
 
-.PHONY: help up all down restart ps logs clean
+SUPPORTED_COMMANDS := up stop down logs restart
+ifneq ($(filter $(SUPPORTED_COMMANDS),$(firstword $(MAKECMDGOALS))),)
+  PROFILES_LIST := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  PROFILE_FLAGS := $(foreach p,$(PROFILES_LIST),--profile $(p))
+  $(eval $(PROFILES_LIST):;@:)
+endif
+
+.PHONY: help up stop all down restart ps logs clean check-tools \
+         db-cache infra stream full-stack
 
 help: ## Show this help message
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo "\033[36mUsage:\033[0m make <command> <profile1> <profile2> [D=\"\"]"
+	@echo ""
+	@echo "\033[36mCommands:\033[0m"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "\033[36mAvailable Profiles (detected from docker-compose):\033[0m"
+	@grep 'profiles:' compose.yml | sed 's/.*\[\(.*\)\].*/  - \1/' | sed 's/,/\n  -/g' | sort -u
 
 check-tools:
 	@command -v docker >/dev/null 2>&1 || { echo "\033[31mError: docker is not installed.\033[0m"; exit 1; }
 	@command -v docker compose >/dev/null 2>&1 || { echo "\033[31mError: docker-compose is not installed.\033[0m"; exit 1; }
 	@echo "\033[32mAll tools are installed! \033[0m"
 
-up: check-tools ## Start core services (without profiles)
-	$(COMPOSE) up -d
 
-all: ## Start all services including all profiles (kafka, redis, psql, mail, tools, etc.)
-	$(ALL_PROFILES) $(COMPOSE) up -d
+up: check-tools ## Start services (core by default, or specific profiles e.g. 'make up psql redis', D="")
+	@if [ -z "$(PROFILES_LIST)" ]; then $(COMPOSE) up $(D); \
+	else $(COMPOSE) $(PROFILE_FLAGS) up $(D); fi
 
-mysql: ## Focus: Start postgres and pgadmin services 
-	$(COMPOSE) --profile mysql up -d
+stop: ## Stop services (all by default, or specific profiles e.g. 'make stop psql redis')
+	@if [ -z "$(PROFILES_LIST)" ]; then $(ALL_PROFILES) $(COMPOSE) stop; \
+	else $(COMPOSE) $(PROFILE_FLAGS) stop; fi
 
-db-cache: ## Focus: Start MySQL and Redis services
-	$(COMPOSE) --profile mysql --profile redis up -d
+down: ## Remove services (all by default, or specific profiles e.g. 'make down psql redis')
+	@if [ -z "$(PROFILES_LIST)" ]; then $(ALL_PROFILES) $(COMPOSE) down; \
+	else $(COMPOSE) $(PROFILE_FLAGS) down; fi
 
-infra: ## Focus: Start infrastructure services (psql, redis, mail)
-	$(COMPOSE) --profile psql --profile redis --profile mail up -d
+logs: ## Follow logs (all by default, or specific profiles e.g. 'make logs psql redis')
+	@if [ -z "$(PROFILES_LIST)" ]; then $(ALL_PROFILES) $(COMPOSE) logs -f --tail=100; \
+	else $(COMPOSE) $(PROFILE_FLAGS) logs -f --tail=100; fi
 
-psql: ## Focus: Start postgres and pgadmin services 
-	$(COMPOSE) --profile psql up -d
-
-redis: ## Focus: Start redis and redis insight services 
-	$(COMPOSE) --profile redis  up -d
-
-mail: ## Focus: Start mail service
-	$(COMPOSE)  --profile mail up -d
-
-stream: ## Focus: Start streaming stack (kafka, redis)
-	$(COMPOSE) --profile kafka --profile redis up -d
-
-kafka: ## Focus: Start kafka, kafka-ui and zookeeper services 
-	$(COMPOSE) --profile kafka up -d
-
-docker: ## Focus: Start portainer and dozzle services
-	$(COMPOSE) --profile docker  up -d
-
-tools: ## Focus: Start minio service
-	$(COMPOSE) --profile tools  up -d
-
-obs: ## Focus: Start Prometheus and Grafana
-	$(COMPOSE) --profile obs up -d
-
-security: ## Focus: Start HashiCorp Vault
-	$(COMPOSE) --profile security up -d
-
-proxy: ## Focus: Start  Cloudflared
-	$(COMPOSE) --profile proxy up -d
-
-goma: ## Focus: Start  goma-gateway and goma-provider
-	$(COMPOSE) --profile goma up -d
-
-full-stack: ## Focus: Standard dev environment (MySQL, Redis, Mail, Proxy)
-	$(COMPOSE) --profile mysql --profile redis --profile mail --profile proxy up -d
+restart: ## Restart services (all by default, or specific profiles e.g. 'make restart psql')
+	@if [ -z "$(PROFILES_LIST)" ]; then $(ALL_PROFILES) $(COMPOSE) restart; \
+	else $(COMPOSE) $(PROFILE_FLAGS) restart; fi
 
 
-stats: ## Display resource usage for all services
+all: ## Start all services including all profiles
+	$(ALL_PROFILES) $(COMPOSE) up $(D)
+
+db-cache: ## Focus: MySQL and Redis
+	$(COMPOSE) --profile mysql --profile redis up $(D)
+
+infra: ## Focus: psql, redis, mail
+	$(COMPOSE) --profile psql --profile redis --profile mail up $(D)
+
+stream: ## Focus: kafka, redis
+	$(COMPOSE) --profile kafka --profile redis up $(D)
+
+full-stack: ## Focus: Standard dev environment
+	$(COMPOSE) --profile mysql --profile redis --profile mail --profile proxy up $(D)
+
+stats: ## Display resource usage
 	docker stats --no-stream
 
-version: ## Show versions of images used
+version: ## Show versions of images
 	$(ALL_PROFILES) $(COMPOSE) images
 
-down: ## Stop and remove all containers, networks, and images (all profiles)
+down-all: ## Stop and remove everything (all profiles)
 	$(ALL_PROFILES) $(COMPOSE) down
 
-restart: ## Restart all running containers
+restart-all: ## Restart all running containers
 	$(ALL_PROFILES) $(COMPOSE) restart
 
 ps: ## List all containers status
 	$(ALL_PROFILES) $(COMPOSE) ps
 
-logs: ## Follow logs of all containers
+logs-all: ## Follow logs of all containers
 	$(ALL_PROFILES) $(COMPOSE) logs -f --tail=100
 
-clean: ## Deep clean: remove stopped containers and unused networks
+clean: ## Deep clean
 	$(ALL_PROFILES) $(COMPOSE) down --remove-orphans
 	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,86 @@
+COMPOSE = docker compose
+ALL_PROFILES = COMPOSE_PROFILES="*"
+
+.PHONY: help up all down restart ps logs clean
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+check-tools:
+	@command -v docker >/dev/null 2>&1 || { echo "\033[31mError: docker is not installed.\033[0m"; exit 1; }
+	@command -v docker compose >/dev/null 2>&1 || { echo "\033[31mError: docker-compose is not installed.\033[0m"; exit 1; }
+	@echo "\033[32mAll tools are installed! \033[0m"
+
+up: check-tools ## Start core services (without profiles)
+	$(COMPOSE) up -d
+
+all: ## Start all services including all profiles (kafka, redis, psql, mail, tools, etc.)
+	$(ALL_PROFILES) $(COMPOSE) up -d
+
+mysql: ## Focus: Start postgres and pgadmin services 
+	$(COMPOSE) --profile mysql up -d
+
+db-cache: ## Focus: Start MySQL and Redis services
+	$(COMPOSE) --profile mysql --profile redis up -d
+
+infra: ## Focus: Start infrastructure services (psql, redis, mail)
+	$(COMPOSE) --profile psql --profile redis --profile mail up -d
+
+psql: ## Focus: Start postgres and pgadmin services 
+	$(COMPOSE) --profile psql up -d
+
+redis: ## Focus: Start redis and redis insight services 
+	$(COMPOSE) --profile redis  up -d
+
+mail: ## Focus: Start mail service
+	$(COMPOSE)  --profile mail up -d
+
+stream: ## Focus: Start streaming stack (kafka, redis)
+	$(COMPOSE) --profile kafka --profile redis up -d
+
+kafka: ## Focus: Start kafka, kafka-ui and zookeeper services 
+	$(COMPOSE) --profile kafka up -d
+
+docker: ## Focus: Start portainer and dozzle services
+	$(COMPOSE) --profile docker  up -d
+
+tools: ## Focus: Start minio service
+	$(COMPOSE) --profile tools  up -d
+
+obs: ## Focus: Start Prometheus and Grafana
+	$(COMPOSE) --profile obs up -d
+
+security: ## Focus: Start HashiCorp Vault
+	$(COMPOSE) --profile security up -d
+
+proxy: ## Focus: Start  Cloudflared
+	$(COMPOSE) --profile proxy up -d
+
+goma: ## Focus: Start  goma-gateway and goma-provider
+	$(COMPOSE) --profile goma up -d
+
+full-stack: ## Focus: Standard dev environment (MySQL, Redis, Mail, Proxy)
+	$(COMPOSE) --profile mysql --profile redis --profile mail --profile proxy up -d
+
+
+stats: ## Display resource usage for all services
+	docker stats --no-stream
+
+version: ## Show versions of images used
+	$(ALL_PROFILES) $(COMPOSE) images
+
+down: ## Stop and remove all containers, networks, and images (all profiles)
+	$(ALL_PROFILES) $(COMPOSE) down
+
+restart: ## Restart all running containers
+	$(ALL_PROFILES) $(COMPOSE) restart
+
+ps: ## List all containers status
+	$(ALL_PROFILES) $(COMPOSE) ps
+
+logs: ## Follow logs of all containers
+	$(ALL_PROFILES) $(COMPOSE) logs -f --tail=100
+
+clean: ## Deep clean: remove stopped containers and unused networks
+	$(ALL_PROFILES) $(COMPOSE) down --remove-orphans
+	docker system prune -f

--- a/README.md
+++ b/README.md
@@ -20,33 +20,47 @@ cp .env.example .env
 Open `.env` and set `DOCKER_NETWORK=devtools`. This is also where you'll define your database passwords, Cloudflare tokens, and other secrets.
 
 ### 3. Usage & Essential Commands
-We use `make` to keep things simple. Here are the commands you'll use most often:
+We use `make` to keep things simple. The core commands can be applied to all services or dynamically to specific profiles!
 
-- `all`:              Start all services including all profiles (kafka, redis, psql, mail, tools, etc.)
+**Command Syntax:** 
+`make <command> [profile1] [profile2] ...`
+
+#### Dynamic Core Commands
+These commands adapt based on the profiles you provide. If no profile is provided, they fall back to their default scope:
+- `up`:               Start services (core by default. Use e.g. `make up psql redis` for specific profiles)
+- `down`:             Stop and remove services (all by default, or specific profiles e.g. `make down psql`)
+- `stop`:             Stop services without removing them (all by default, or specific profiles e.g. `make stop psql`)
+- `restart`:          Restart services (all by default, or specific profiles e.g. `make restart psql`)
+- `logs`:             Follow logs (all by default, or specific profiles e.g. `make logs psql`)
+
+#### Environment Stacks
+These are helpful shortcuts to automatically start (`make <stack>`) combined groups of profiles:
+- `all`:              Start **all** services across every profile
+- `full-stack`:       Standard dev environment (MySQL, Redis, Mail, Proxy)
+- `infra`:            Infrastructure services (PostgreSQL, Redis, Mail)
+- `db-cache`:         Database & Caching (MySQL, Redis)
+- `stream`:           Streaming infrastructure (Kafka, Redis)
+
+#### Utilities
+- `ps`:               List status of all containers
+- `stats`:            Display resource usage metrics
 - `clean`:            Deep clean: remove stopped containers and unused networks
-- `db-cache`:         Focus: Start MySQL and Redis services
-- `docker`:           Focus: Start portainer and dozzle services
-- `down`:             Stop and remove all containers, networks, and images (all profiles)
-- `goma`              Focus: start Goma-gateway and Goma-provider
-- `full-stack`:       Focus: Standard dev environment (MySQL, Redis, Mail, Proxy)
-- `help`:             Show this help message
-- `infra`:            Focus: Start infrastructure services (psql, redis, mail)
-- `kafka`:            Focus: Start kafka, kafka-ui and zookeeper services 
-- `logs`:             Follow logs of all containers
-- `mail`:             Focus: Start mail service
-- `mysql`:            Focus: Start postgres and pgadmin services 
-- `obs`:              Focus: Start Prometheus and Grafana
-- `proxy`:            Focus: Start  Cloudflared
-- `ps`:               List all containers status
-- `psql`:             Focus: Start postgres and pgadmin services 
-- `redis`:            Focus: Start redis and redis insight services 
-- `restart`:          Restart all running containers
-- `security`:         Focus: Start HashiCorp Vault
-- `stats`:            Display resource usage for all services
-- `stream`:           Focus: Start streaming stack (kafka, redis)
-- `tools`:            Focus: Start minio service
-- `up`:               Start core services (without profiles)
 - `version`:          Show versions of images used
+- `help`:             Show the Makefile help message
+
+#### Single Stacks
+Quickly start specific individual tools (`make up/down/stop/restart/log <stack>`):
+- `docker`:           Portainer and Dozzle
+- `goma`:             Goma-gateway and Goma-provider
+- `kafka`:            Kafka, Kafka-UI, and Zookeeper
+- `mail`:             Mailpit
+- `mysql`:            MySQL and phpMyAdmin
+- `obs`:              Prometheus and Grafana
+- `proxy`:            Cloudflared
+- `psql`:             PostgreSQL and pgAdmin
+- `redis`:            Redis and Redis Insight
+- `security`:         HashiCorp Vault
+- `tools`:            MinIO
 
 ## Stacks & Profiles
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,110 @@
-# docker-dev-tools
-Docker local development tools
+# Docker Development Infrastructure
 
-Tools:
- - Zookeeper
- - Kafka
- - Redis
- - Mysql
- - Phpmyadmin
- - Postgres
- - Minio Object Storage, S3 alternative
- - pgadmin4
+This repository is a collection of Docker-based tools and services pre-configured for local development. Whether you're working with streaming data, relational databases, or need a robust observability stack, this setup provides a modular and easy-to-manage infrastructure using Docker Compose and a simple Makefile.
 
-## To run :
-> docker network create internal
+## Quick Start
 
-```sh
-docker-compose up -d
+### 1. Create the Docker Network
+First, you need to manually create the Docker network that all services will share. We'll call it `devtools`:
 
+```bash
+docker network create devtools
 ```
 
-Networks :
- - internal
+### 2. Configure Your Environment
+Copy the example environment file and make sure the `DOCKER_NETWORK` variable matches the name you chose in the previous step:
+
+```bash
+cp .env.example .env
+```
+Open `.env` and set `DOCKER_NETWORK=devtools`. This is also where you'll define your database passwords, Cloudflare tokens, and other secrets.
+
+### 3. Usage & Essential Commands
+We use `make` to keep things simple. Here are the commands you'll use most often:
+
+- `all`:              Start all services including all profiles (kafka, redis, psql, mail, tools, etc.)
+- `clean`:            Deep clean: remove stopped containers and unused networks
+- `db-cache`:         Focus: Start MySQL and Redis services
+- `docker`:           Focus: Start portainer and dozzle services
+- `down`:             Stop and remove all containers, networks, and images (all profiles)
+- `goma`              Focus: start Goma-gateway and Goma-provider
+- `full-stack`:       Focus: Standard dev environment (MySQL, Redis, Mail, Proxy)
+- `help`:             Show this help message
+- `infra`:            Focus: Start infrastructure services (psql, redis, mail)
+- `kafka`:            Focus: Start kafka, kafka-ui and zookeeper services 
+- `logs`:             Follow logs of all containers
+- `mail`:             Focus: Start mail service
+- `mysql`:            Focus: Start postgres and pgadmin services 
+- `obs`:              Focus: Start Prometheus and Grafana
+- `proxy`:            Focus: Start  Cloudflared
+- `ps`:               List all containers status
+- `psql`:             Focus: Start postgres and pgadmin services 
+- `redis`:            Focus: Start redis and redis insight services 
+- `restart`:          Restart all running containers
+- `security`:         Focus: Start HashiCorp Vault
+- `stats`:            Display resource usage for all services
+- `stream`:           Focus: Start streaming stack (kafka, redis)
+- `tools`:            Focus: Start minio service
+- `up`:               Start core services (without profiles)
+- `version`:          Show versions of images used
+
+## Stacks & Profiles
+
+Instead of running everything at once, you can pick the specific "stack" you need for your current task. Each one corresponds to a Docker Compose profile:
+
+- **Streaming (`kafka`)**: Includes Zookeeper, Kafka, and the Kafka-UI for management.
+- **Caching (`redis`)**: Redis server paired with Redis Insight for visual data exploration.
+- **SQL Databases**:
+    - `mysql`: Standard MySQL server plus phpMyAdmin for web-based access.
+    - `psql`: PostgreSQL server along with pgAdmin4.
+- **Observability (`obs`)**: Prometheus for metrics and Grafana for dashboards.
+- **Infrastructure Management (`docker`)**: Portainer (UI) and Dozzle (real-time log viewer).
+- **Security (`security`)**: A local HashiCorp Vault instance.
+- **Storage & Documentation (`tools`)**: MinIO (S3-compatible storage) and Swagger UI.
+- **Email Testing (`mail`)**: Mailpit, which catches all outgoing SMTP mail for local debugging.
+- **Tunneling (`proxy`)**: Cloudflared for exposing your local services securely.
+- **Goma (`goma`)**: Goma-gateway reverse proxy and goma provider 
+
+## Service Access Directory
+
+| Service | Access Type | Host Port | URL / Connection String |
+| :--- | :--- | :--- | :--- |
+| **Grafana** | **Browser** | 8081 | [http://localhost:8081](http://localhost:8081) (`admin` / `admin`) |
+| **Goma-Gateway** | **Browser** | 9090 | [http://localhost](http://localhost) |
+| **Prometheus** | **Browser** | 9090 | [http://localhost:9090](http://localhost:9090) |
+| **Portainer** | **Browser** | 8079 | [http://localhost:8079](http://localhost:8079) |
+| **Dozzle** | **Browser** | 8078 | [http://localhost:8078](http://localhost:8078) |
+| **phpMyAdmin** | **Browser** | 8075 | [http://localhost:8075](http://localhost:8075) |
+| **pgAdmin4** | **Browser** | 8076 | [http://localhost:8076](http://localhost:8076) |
+| **Kafka UI** | **Browser** | 8074 | [http://localhost:8074](http://localhost:8074) |
+| **Redis Insight** | **Browser** | 8077 | [http://localhost:8077](http://localhost:8077) |
+| **MinIO Console**| **Browser** | 9001 | [http://localhost:9001](http://localhost:9001) |
+| **Mailpit UI** | **Browser** | 8025 | [http://localhost:8025](http://localhost:8025) |
+| **Swagger UI** | **Browser** | 8083 | [http://localhost:8083](http://localhost:8083) |
+| **Vault** | **Browser** | 8200 | [http://localhost:8200](http://localhost:8200) |
+| **MySQL** | Direct/CLI | 3306 | `localhost:3306` |
+| **PostgreSQL** | Direct/CLI | 5432 | `localhost:5432` |
+| **Kafka** | Direct/CLI | 9092 | `localhost:9092` |
+| **Redis** | Direct/CLI | 6379 | `localhost:6379` |
+| **MinIO API** | Direct/CLI | 9000 | `localhost:9000` |
+| **Mailpit SMTP** | Direct/CLI | 1025 | `localhost:1025` |
+
+## External Access Details
+
+### Cloudflare Tunnels
+Used for exposing local services to the internet without opening ports on your router.
+- Get your token from the [Cloudflare Dashboard](https://dash.cloudflare.com/).
+- Paste it into `CLOUDFLARE_TOKEN` in your `.env`.
+
+### HashiCorp Vault
+- **Default Root Token**: `root`
+- Initialized in dev mode for immediate use.
+
+## Technical Resources
+
+- [Official Docker Docs](https://docs.docker.com/)
+- [Prometheus Overview](https://prometheus.io/docs/introduction/overview/)
+- [Cloudflare Tunnels Guide](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+- [Goma Gateway Documentation](https://jkaninda.github.io/goma-gateway)
+- [Goma Gateway on GitHub](https://github.com/jkaninda/goma-gateway)
+- [Goma Docker Provider](https://github.com/jkaninda/goma-docker-provider)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     networks:
       - ${DOCKER_NETWORK:-devtools}
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:5.2.3-fpm-alpine
+    image: phpmyadmin:5.2.3-apache
     container_name: phpmyadmin
     labels:
       - "goma.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # --- MESSAGE BROKING & STREAMING (Kafka Stack) ---
   zookeeper:
-    image: bitnami/zookeeper:latest
+    image: wurstmeister/zookeeper
     container_name: zookeeper
     profiles: [kafka]
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,9 @@ services:
     labels:
       - "goma.enable=true"
       - "goma.name=kafka"
-      # - "goma.hosts=kafka.localhost"
-      - "goma.path=/kafka"
-      - "goma.rewrite=/kafka"
+      - "goma.hosts=kafka.localhost"
+      #- "goma.path=/kafka"
+      #- "goma.rewrite=/"
       - "goma.port=8080"
     restart: unless-stopped
     ports:
@@ -61,6 +61,13 @@ services:
   redis-insight:
     image: redislabs/redisinsight:3.2
     container_name: redis-insight
+    labels:
+      - "goma.enable=true"
+      - "goma.name=redis-insight"
+      - "goma.hosts=redis-insight.localhost"
+      #- "goma.path=/redis-insight"
+      #- "goma.rewrite=/"
+      - "goma.port=5540"
     volumes:
       - ${DATA_PATH:-./data}/redisinsight:/data
     ports:
@@ -72,6 +79,13 @@ services:
   dozzle:
     image: amir20/dozzle:latest
     container_name: dozzle
+    labels:
+      - "goma.enable=true"
+      - "goma.name=dozzle"
+      - "goma.hosts=dozzle.localhost"
+      #- "goma.path=/dozzle"
+      #- "goma.rewrite=/"
+      - "goma.port=8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
@@ -82,6 +96,13 @@ services:
   portainer:
     image: portainer/portainer-ce:latest
     container_name: portainer
+    labels:
+      - "goma.enable=true"
+      - "goma.name=portainer"
+      - "goma.hosts=portainer.localhost"
+      #- "goma.path=/portainer"
+      #- "goma.rewrite=/"
+      - "goma.port=9000"
     command: -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -112,6 +133,13 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:5.2.3-fpm-alpine
     container_name: phpmyadmin
+    labels:
+      - "goma.enable=true"
+      - "goma.name=phpmyadmin"
+      - "goma.hosts=phpmyadmin.localhost"
+      #- "goma.path=/phpmyadmin"
+      #- "goma.rewrite=/"
+      - "goma.port=80"
     depends_on:
       - mysql
     environment:
@@ -138,8 +166,16 @@ services:
     networks:
       - ${DOCKER_NETWORK:-devtools}
   pgadmin:
-    container_name: pgadmin
     image: dpage/pgadmin4:9.13
+    container_name: pgadmin
+    labels:
+      - "goma.enable=true"
+      - "goma.name=pgadmin"
+      - "goma.hosts=pgadmin.localhost"
+      #- "goma.path=/pgadmin"
+      #- "goma.rewrite=/"
+      - "goma.port=80"
+      - "goma.security.forward_host_headers=true"
     volumes:
       - ${DATA_PATH:-.data}/pgadmin:/var/lib/pgadmin
     environment:
@@ -154,6 +190,13 @@ services:
   minio:
     image: "minio/minio"
     container_name: minio
+    labels:
+      - "goma.enable=true"
+      - "goma.name=minio"
+      - "goma.hosts=minio.localhost"
+      #- "goma.path=/minio"
+      #- "goma.rewrite=/"
+      - "goma.port=9001"
     restart: unless-stopped
     command: server /data --console-address ":9001"
     ports:
@@ -172,6 +215,13 @@ services:
   mailpit:
     image: axllent/mailpit
     container_name: mailpit
+    labels:
+      - "goma.enable=true"
+      - "goma.name=mailpit"
+      - "goma.hosts=mailpit.localhost"
+      #- "goma.path=/mailpit"
+      #- "goma.rewrite=/"
+      - "goma.port=8025"
     ports:
       - "8025:8025" # UI
       - "1025:1025" # SMTP
@@ -182,6 +232,13 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
+    labels:
+      - "goma.enable=true"
+      - "goma.name=prometheus"
+      - "goma.hosts=prometheus.localhost"
+      #- "goma.path=/prometheus"
+      #- "goma.rewrite=/"
+      - "goma.port=9090"
     ports:
       - "9090:9090"
     volumes:
@@ -193,6 +250,13 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
+    labels:
+      - "goma.enable=true"
+      - "goma.name=grafana"
+      - "goma.hosts=grafana.localhost"
+      #- "goma.path=/grafana"
+      #- "goma.rewrite=/"
+      - "goma.port=3000"
     ports:
       - "8081:3000"
     profiles: [obs]
@@ -203,6 +267,13 @@ services:
   vault:
     image: hashicorp/vault:latest
     container_name: vault
+    labels:
+      - "goma.enable=true"
+      - "goma.name=vault"
+      - "goma.hosts=vault.localhost"
+      #- "goma.path=/vault"
+      #- "goma.rewrite=/"
+      - "goma.port=8200"
     ports:
       - "8200:8200"
     environment:
@@ -218,6 +289,13 @@ services:
   swagger-ui:
     image: swaggerapi/swagger-ui
     container_name: swagger-ui
+    labels:
+      - "goma.enable=true"
+      - "goma.name=swagger-ui"
+      - "goma.hosts=swagger-ui.localhost"
+      #- "goma.path=/swagger-ui"
+      #- "goma.rewrite=/"
+      - "goma.port=8080"
     ports:
       - "8083:8080"
     profiles: [tools]
@@ -232,7 +310,7 @@ services:
     profiles: [proxy]
     networks:
       - ${DOCKER_NETWORK:-devtools}
-      
+
   # --- GOMA GATEWAY ---
   goma-gateway:
     image: jkaninda/goma-gateway
@@ -251,8 +329,12 @@ services:
       # Uncomment if using Docker provider for dynamic configuration
       - ${DATA_PATH:-./data}/goma/providers:/etc/goma/providers
     environment:
-      -  GOMA_EXTRA_CONFIG_DIR=/etc/goma/providers
-      -  GOMA_EXTRA_CONFIG_WATCH=true
+      - GOMA_LOG_LEVEL=info
+      - GOMA_ENTRYPOINT_WEB_ADDRESS=:80
+      - GOMA_ENTRYPOINT_WEB_SECURE_ADDRESS=:443
+      - GOMA_FILE_PROVIDER_ENABLED=true
+      - GOMA_FILE_PROVIDER_WATCH=true
+      - GOMA_FILE_PROVIDER_DIRECTORY=/etc/goma/providers/dev
     healthcheck:
       test: curl -f http://localhost/healthz || exit 1
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
     command: server /data --console-address ":9001"
     ports:
       # API Port
-      - "9000:9000"
+      - "9002:9000"
       # Console Port
       - "9001:9001"
     environment:
@@ -261,16 +261,23 @@ services:
       timeout: 10s
     networks:
       - ${DOCKER_NETWORK:-devtools}
-  goma-provider:
-    image: jkaninda/goma-docker-provider
-    container_name: goma-provider
+  goma-admin:
+    image: jkaninda/goma-admin:latest
+    container_name: goma-admin
     profiles: [goma]
+    restart: unless-stopped
+    ports:
+      - "${GOMA_PORT:-9000}:9000"
+    env_file:
+      - .env
+    labels:
+      - "goma.enable=true"
+      - "goma.port=9000"
+      - "goma.hosts=goma-admin.localhost"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro 
       - ${DATA_PATH:-./data}/goma/providers:/etc/goma/providers
-    environment:
-      - GOMA_OUTPUT_DIR=/etc/goma/providers # Optional, default /etc/goma/providers
-      - GOMA_ENABLE_SWARM=false # Enable Swarm mode, default false
+      # Uncomment to enable the Docker provider (auto-discover routes from labels)
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - ${DOCKER_NETWORK:-devtools}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,47 +1,104 @@
-version: "3.7"
 services:
-   kafka:
-    image: 'bitnami/kafka:3.2.3'
+  # --- MESSAGE BROKING & STREAMING (Kafka Stack) ---
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    container_name: zookeeper
+    profiles: [kafka]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+
+  kafka:
+    image: wurstmeister/kafka:2.13-2.8.1
     container_name: kafka
-    restart: unless-stopped
-    environment:
-      - ALLOW_PLAINTEXT_LISTENER=yes
-    volumes:
-      - ./kafka:/bitnami/kafka
+    depends_on:
+      - zookeeper
     ports:
       - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - ${DATA_PATH:-./data}/kafka:/kafka
+    profiles: [kafka]
     networks:
-     - internal
-   kafka-ui:
-    image: provectuslabs/kafka-ui:master
+      - ${DOCKER_NETWORK:-devtools}
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
     container_name: kafka-ui
+    labels:
+      - "goma.enable=true"
+      - "goma.name=kafka"
+      # - "goma.hosts=kafka.localhost"
+      - "goma.path=/kafka"
+      - "goma.rewrite=/kafka"
+      - "goma.port=8080"
+    restart: unless-stopped
     ports:
       - "8074:8080"
-    restart: unless-stopped
     environment:
       - KAFKA_CLUSTERS_0_NAME=dev-cluster
       - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
       # If you prefer UI for Apache Kafka in read only mode
-     # - KAFKA_CLUSTERS_0_READONLY=true
+      # - KAFKA_CLUSTERS_0_READONLY=true
+    profiles: [kafka]
     networks:
-     - internal  
-   redis:
-    image: redis:alpine
+      - ${DOCKER_NETWORK:-devtools}
+
+  # --- CACHING & NO-SQL ---
+  redis:
+    image: redis:8.6.2-alpine
     container_name: redis
     restart: unless-stopped
     command: redis-server --appendonly yes --requirepass "${REDIS_PASSWORD}"
     volumes:
-      - ./redis:/data
+      - ${DATA_PATH:-./data}/redis:/data
     ports:
-     - "6379:6379"
+      - "6379:6379"
+    profiles: [redis]
     networks:
-       - internal
-   mysql:
-    image: mysql:5.7.39
+      - ${DOCKER_NETWORK:-devtools}
+  redis-insight:
+    image: redislabs/redisinsight:3.2
+    container_name: redis-insight
+    volumes:
+      - ${DATA_PATH:-./data}/redisinsight:/data
+    ports:
+      - "8077:5540"
+    profiles: [redis]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+  # --- INFRASTRUCTURE & MONITORING (Docker Management) ---
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: dozzle
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "8078:8080"
+    profiles: [docker]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    command: -H unix:///var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./portainer:/data
+    ports:
+      - "8079:9000"
+    profiles: [docker]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+  # --- RELATIONAL DATABASES (SQL) ---
+  mysql:
+    image: mysql:8.4
     container_name: mysql
     restart: unless-stopped
     volumes:
-      - ./mysql:/var/lib/mysql
+      - ${DATA_PATH:-./data}/mysql:/var/lib/mysql
+      - ./db.sql:/docker-entrypoint-initdb.d/init.sql
     environment:
       MYSQL_DATABASE: ${DB_DATABASE}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
@@ -49,62 +106,175 @@ services:
       MYSQL_USER: ${DB_USERNAME}
     ports:
       - "3306:3306"
+    profiles: [mysql]
     networks:
-      - internal
-   phpmyadmin:
-    image: phpmyadmin:5.2.0-apache
+      - ${DOCKER_NETWORK:-devtools}
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:5.2.3-fpm-alpine
     container_name: phpmyadmin
     depends_on:
-       - mysql
+      - mysql
     environment:
       PMA_HOST: mysql
       PMA_PORT: 3306
     restart: unless-stopped
     ports:
       - "8075:80"
+    profiles: [mysql]
     networks:
-      - internal
-   postgres:
-    image: postgres:14.5 
+      - ${DOCKER_NETWORK:-devtools}
+  postgres:
+    image: postgres:18.3
     container_name: postgres
     restart: unless-stopped
     volumes:
-      - ./postgres:/var/lib/postgresql/data
+      - ${DATA_PATH:-./data}/postgres:/var/lib/postgresql
     environment:
-      POSTGRES_DB: ${DB_DATABASE}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
     ports:
       - "5432:5432"
+    profiles: [psql]
     networks:
-      - internal
-   pgadmin4:
-    container_name: pgadmin4
-    image: dpage/pgadmin4:7.3
+      - ${DOCKER_NETWORK:-devtools}
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4:9.13
+    volumes:
+      - ${DATA_PATH:-.data}/pgadmin:/var/lib/pgadmin
     environment:
-      - PGADMIN_DEFAULT_EMAIL=admin@example.com
-      - PGADMIN_DEFAULT_PASSWORD=password
+      PGADMIN_DEFAULT_EMAIL: ${DB_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${DB_PASSWORD}
     ports:
       - "8076:80"
+    profiles: [psql]
     networks:
-      - internal
-   minio:
-    image: 'bitnami/minio:2023.7.7'
-    container_name:  minio
+      - ${DOCKER_NETWORK:-devtools}
+  # --- DEVELOPMENT TOOLS (Mail, Storage, API) ---
+  minio:
+    image: "minio/minio"
+    container_name: minio
     restart: unless-stopped
+    command: server /data --console-address ":9001"
     ports:
       # API Port
-      - '9000:9000'
+      - "9000:9000"
       # Console Port
-      - '9001:9001'
+      - "9001:9001"
     environment:
-      - MINIO_ROOT_USER=admin
-      - MINIO_ROOT_PASSWORD=password
+      MINIO_ROOT_USER: ${DB_USERNAME}
+      MINIO_ROOT_PASSWORD: ${DB_PASSWORD}
     volumes:
-      - ./minio:/data
+      - ${DATA_PATH:-./data}/minio:/data
+    profiles: [tools]
     networks:
-      - internal
+      - ${DOCKER_NETWORK:-devtools}
+  mailpit:
+    image: axllent/mailpit
+    container_name: mailpit
+    ports:
+      - "8025:8025" # UI
+      - "1025:1025" # SMTP
+    profiles: [mail]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+  # --- OBSERVABILITY ---
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ${DATA_PATH:-./data}/prometheus:/etc/prometheus
+    profiles: [obs]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "8081:3000"
+    profiles: [obs]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+
+  # --- SECURITY ---
+  vault:
+    image: hashicorp/vault:latest
+    container_name: vault
+    ports:
+      - "8200:8200"
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=root
+      - VAULT_ADDR=http://0.0.0.0:8200
+    cap_add:
+      - IPC_LOCK
+    profiles: [security]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+
+  # --- API DOCS ---
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    container_name: swagger-ui
+    ports:
+      - "8083:8080"
+    profiles: [tools]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+
+  # --- NETWORKING & PROXY ---
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TOKEN}
+    profiles: [proxy]
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+      
+  # --- GOMA GATEWAY ---
+  goma-gateway:
+    image: jkaninda/goma-gateway
+    container_name: gateway
+    profiles: [goma]
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      # Gateway configuration directory
+      - ${DATA_PATH:-./data}/goma:/etc/goma
+      # SSL certificates managed by Let's Encrypt
+      - ${DATA_PATH:-./data}/goma/letsencrypt:/etc/letsencrypt
+      # Optional: Docker provider configuration files
+      # Uncomment if using Docker provider for dynamic configuration
+      - ${DATA_PATH:-./data}/goma/providers:/etc/goma/providers
+    environment:
+      -  GOMA_EXTRA_CONFIG_DIR=/etc/goma/providers
+      -  GOMA_EXTRA_CONFIG_WATCH=true
+    healthcheck:
+      test: curl -f http://localhost/healthz || exit 1
+      interval: 30s
+      retries: 5
+      start_period: 20s
+      timeout: 10s
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+  goma-provider:
+    image: jkaninda/goma-docker-provider
+    container_name: goma-provider
+    profiles: [goma]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro 
+      - ${DATA_PATH:-./data}/goma/providers:/etc/goma/providers
+    environment:
+      - GOMA_OUTPUT_DIR=/etc/goma/providers # Optional, default /etc/goma/providers
+      - GOMA_ENABLE_SWARM=false # Enable Swarm mode, default false
+    networks:
+      - ${DOCKER_NETWORK:-devtools}
+
 networks:
-  internal:
-    external: false
-    name: internal 
+  devtools:
+    external: true
+    name: ${DOCKER_NETWORK:-devtools}


### PR DESCRIPTION
- Restructure docker-compose.yml into logical stacks using profiles
- Add monitoring (Prometheus/Grafana), security (Vault), and tunneling (Cloudflare)
- Transition from hardcoded 'internal' network to external 'devtools' network
- Consolidate environment variables in .env.example
-  Add Makefile for better services management with profiles
-  update README with detailed usage instructions and service access information